### PR TITLE
Support of Swift Package Manager

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/MXScroll/Classes/RxScrollKit.swift
+++ b/MXScroll/Classes/RxScrollKit.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 cillyfly. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import EasyPeasy
 #if !RX_NO_MODULE
 import RxCocoa
@@ -18,7 +18,7 @@ extension Reactive where Base == UIScrollView{
         return Binder(self.base){(scroll,value) in
             scroll.easy.layout(
                 Height(value)
-            ) 
+            )
         }
     }
     

--- a/MXScroll/Classes/RxViewKit.swift
+++ b/MXScroll/Classes/RxViewKit.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 cillyfly. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import EasyPeasy
 #if !RX_NO_MODULE
 import RxCocoa

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "EasyPeasy",
+        "repositoryURL": "https://github.com/nakiostudio/EasyPeasy",
+        "state": {
+          "branch": null,
+          "revision": "5855b14d7c8a7f510be8275794ec9afeba07b4cf",
+          "version": "1.9.2"
+        }
+      },
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift",
+        "state": {
+          "branch": null,
+          "revision": "b3e888b4972d9bc76495dd74d30a8c7fad4b9395",
+          "version": "5.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "MXScroll",
+    platforms: [.iOS(.v10)],
+    products: [
+        .library(name: "MXScroll", targets: ["MXScroll"])
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/nakiostudio/EasyPeasy",
+            .upToNextMajor(from: "1.9.2")
+        ),
+        .package(
+            url: "https://github.com/ReactiveX/RxSwift",
+            .upToNextMajor(from: "5.0.1")
+        )
+    ],
+    targets: [
+        .target(
+            name: "MXScroll",
+            dependencies: ["RxSwift", "RxCocoa", "EasyPeasy"],
+            path: "MXScroll/Classes"
+        )
+    ]
+)


### PR DESCRIPTION
Adds `Package.swift` file which enables usage with SPM.
**Note**, that the most correct usage with SPM will be possible only when there is new release that includes `Package.swift`. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.